### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/page-monitor/page_monitor.py
+++ b/page-monitor/page_monitor.py
@@ -118,8 +118,8 @@ def send_alert(changed_url, date_of_last_check):
         " has changed since it was last checked (" + date_of_last_check + ")."
 
     # prepare actual message
-    message = """\From: %s\nTo: %s\nSubject: %s\n\n%s
-    """ % (FROM, TO, SUBJECT, TEXT)
+    message = """\From: {0!s}\nTo: {1!s}\nSubject: {2!s}\n\n{3!s}
+    """.format(FROM, TO, SUBJECT, TEXT)
 
     # attempt to send the message
     try:


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:fhightower:page-monitor?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:fhightower:page-monitor?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)